### PR TITLE
Restore mask on Pop()

### DIFF
--- a/context.go
+++ b/context.go
@@ -930,7 +930,6 @@ func (dc *Context) Pop() {
 	s := dc.stack
 	x, s := s[len(s)-1], s[:len(s)-1]
 	*dc = *x
-	dc.mask = before.mask
 	dc.strokePath = before.strokePath
 	dc.fillPath = before.fillPath
 	dc.start = before.start


### PR DESCRIPTION
See https://github.com/fogleman/gg/issues/27. `ResetClip()` as suggested there is not the same thing AFAICT.

Preparation for shared graphics context PR.